### PR TITLE
Implement liquidity_fee according to GG's spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ test-ledger
 **/yarn.lock
 
 **/.next
+
+.pnp.*
+.yarn/

--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -125,6 +125,8 @@ async function addCustody(
     closePosition: new BN(100),
     liquidation: new BN(100),
     protocolShare: new BN(10),
+    feeMax: new BN(250),
+    feeOptimal: new BN(10),
   };
   const borrowRate: BorrowRateParams = {
     baseRate: new BN(0),

--- a/programs/perpetuals/src/state/custody.rs
+++ b/programs/perpetuals/src/state/custody.rs
@@ -15,6 +15,7 @@ use {
 pub enum FeesMode {
     Fixed,
     Linear,
+    Optimal,
 }
 
 #[derive(Copy, Clone, PartialEq, AnchorSerialize, AnchorDeserialize, Default, Debug)]
@@ -33,6 +34,9 @@ pub struct Fees {
     pub close_position: u64,
     pub liquidation: u64,
     pub protocol_share: u64,
+    // configs for optimal fee mode
+    pub fee_max: u64,
+    pub fee_optimal: u64,
 }
 
 #[derive(Copy, Clone, PartialEq, AnchorSerialize, AnchorDeserialize, Default, Debug)]
@@ -218,6 +222,8 @@ impl Fees {
             && self.close_position as u128 <= Perpetuals::BPS_POWER
             && self.liquidation as u128 <= Perpetuals::BPS_POWER
             && self.protocol_share as u128 <= Perpetuals::BPS_POWER
+            && self.fee_max as u128 <= Perpetuals::BPS_POWER
+            && self.fee_optimal as u128 <= Perpetuals::BPS_POWER
     }
 }
 

--- a/programs/perpetuals/tests/anchor/basic.ts
+++ b/programs/perpetuals/tests/anchor/basic.ts
@@ -174,6 +174,8 @@ describe("perpetuals", () => {
       closePosition: new BN(100),
       liquidation: new BN(100),
       protocolShare: new BN(10),
+      feeMax: new BN(250),
+      feeOptimal: new BN(10),
     };
     borrowRate = {
       baseRate: new BN(0),
@@ -266,6 +268,8 @@ describe("perpetuals", () => {
         closePosition: "100",
         liquidation: "100",
         protocolShare: "10",
+        feeMax: "250",
+        feeOptimal: "10",
       },
       borrowRate: {
         baseRate: "0",

--- a/programs/perpetuals/tests/native/utils/fixtures.rs
+++ b/programs/perpetuals/tests/native/utils/fixtures.rs
@@ -49,6 +49,8 @@ pub fn fees_linear_regular() -> Fees {
         close_position: 100,
         liquidation: 50,
         protocol_share: 25,
+        fee_max: 0,
+        fee_optimal: 0,
     }
 }
 

--- a/ui/src/lib/types.tsx
+++ b/ui/src/lib/types.tsx
@@ -93,11 +93,14 @@ export interface Fees {
   closePosition: BN;
   liquidation: BN;
   protocolShare: BN;
+  fee_max: BN;
+  fee_optimal: BN;
 }
 
 export enum FeesMode {
   Fixed,
   Linear,
+  Optimal
 }
 
 export interface OracleParams {


### PR DESCRIPTION
Added `Optimal` fee setting.  The existing "trading fee" computation already matched the optimal spec's.

Added basic unit testing.

