### PR TITLE
Support permissionless price feed updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "@types/bn.js": "^5.1.1",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
+    "bn.js": "^5.2.1",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
     "prettier": "^2.8.1",
     "ts-mocha": "^10.0.0",
+    "tweetnacl": "^1.0.3",
     "typescript": "^4.9.4"
   }
 }

--- a/programs/perpetuals/src/error.rs
+++ b/programs/perpetuals/src/error.rs
@@ -56,4 +56,12 @@ pub enum PerpetualsError {
     InstructionNotAllowed,
     #[msg("Token utilization limit exceeded")]
     MaxUtilization,
+    #[msg("Permissionless oracle update must be preceded by Ed25519 signature verification instruction")]
+    PermissionlessOracleMissingSignature,
+    #[msg("Ed25519 signature verification data does not match expected format")]
+    PermissionlessOracleMalformedEd25519Data,
+    #[msg("Ed25519 signature was not signed by the oracle authority")]
+    PermissionlessOracleSignerMismatch,
+    #[msg("Signed message does not match instruction params")]
+    PermissionlessOracleMessageMismatch,
 }

--- a/programs/perpetuals/src/instructions.rs
+++ b/programs/perpetuals/src/instructions.rs
@@ -34,6 +34,7 @@ pub mod liquidate;
 pub mod open_position;
 pub mod remove_collateral;
 pub mod remove_liquidity;
+pub mod set_custom_oracle_price_permissionless;
 pub mod swap;
 pub mod update_pool_aum;
 
@@ -45,7 +46,7 @@ pub use {
     get_liquidation_state::*, get_lp_token_price::*, get_oracle_price::*, get_pnl::*,
     get_remove_liquidity_amount_and_fee::*, get_swap_amount_and_fees::*, init::*, liquidate::*,
     open_position::*, remove_collateral::*, remove_custody::*, remove_liquidity::*, remove_pool::*,
-    set_admin_signers::*, set_custody_config::*, set_custom_oracle_price::*, set_permissions::*,
-    set_test_time::*, swap::*, update_pool_aum::*, upgrade_custody::*, withdraw_fees::*,
-    withdraw_sol_fees::*,
+    set_admin_signers::*, set_custody_config::*, set_custom_oracle_price::*,
+    set_custom_oracle_price_permissionless::*, set_permissions::*, set_test_time::*, swap::*,
+    update_pool_aum::*, upgrade_custody::*, withdraw_fees::*, withdraw_sol_fees::*,
 };

--- a/programs/perpetuals/src/instructions/set_custom_oracle_price.rs
+++ b/programs/perpetuals/src/instructions/set_custom_oracle_price.rs
@@ -89,12 +89,12 @@ pub fn set_custom_oracle_price<'info>(
     }
 
     // update oracle data
-    let oracle_account = ctx.accounts.oracle_account.as_mut();
-    oracle_account.price = params.price;
-    oracle_account.expo = params.expo;
-    oracle_account.conf = params.conf;
-    oracle_account.ema = params.ema;
-    oracle_account.publish_time = params.publish_time;
-
+    ctx.accounts.oracle_account.set(
+        params.price,
+        params.expo,
+        params.conf,
+        params.ema,
+        params.publish_time,
+    );
     Ok(0)
 }

--- a/programs/perpetuals/src/instructions/set_custom_oracle_price_permissionless.rs
+++ b/programs/perpetuals/src/instructions/set_custom_oracle_price_permissionless.rs
@@ -1,0 +1,124 @@
+//! SetCustomOraclePricePermissionless instruction handler
+
+use {
+    crate::{
+        error::PerpetualsError,
+        state::{custody::Custody, oracle::CustomOracle, perpetuals::Perpetuals, pool::Pool},
+    },
+    anchor_lang::prelude::*,
+    solana_program::{ed25519_program, instruction::Instruction, sysvar},
+};
+
+#[derive(Accounts)]
+#[instruction(params: SetCustomOraclePricePermissionlessParams)]
+pub struct SetCustomOraclePricePermissionless<'info> {
+    #[account(
+        seeds = [b"perpetuals"],
+        bump = perpetuals.perpetuals_bump
+    )]
+    pub perpetuals: Box<Account<'info, Perpetuals>>,
+
+    #[account(
+        seeds = [b"pool",
+                 pool.name.as_bytes()],
+        bump = pool.bump
+    )]
+    pub pool: Box<Account<'info, Pool>>,
+
+    #[account(
+        seeds = [b"custody",
+                 pool.key().as_ref(),
+                 custody.mint.as_ref()],
+        constraint = custody.key() == params.custody_account,
+        bump = custody.bump
+    )]
+    pub custody: Box<Account<'info, Custody>>,
+
+    #[account(
+        // Custom oracle must first be initialized by authority before permissionless updates.
+        mut,
+        seeds = [b"oracle_account",
+                 pool.key().as_ref(),
+                 custody.mint.as_ref()],
+        bump
+    )]
+    pub oracle_account: Box<Account<'info, CustomOracle>>,
+
+    /// CHECK: Needed for ed25519 signature verification, to inspect all instructions in this transaction.
+    #[account(address = sysvar::instructions::ID)]
+    pub ix_sysvar: AccountInfo<'info>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq)]
+pub struct SetCustomOraclePricePermissionlessParams {
+    pub custody_account: Pubkey,
+    pub price: u64,
+    pub expo: i32,
+    pub conf: u64,
+    pub ema: u64,
+    pub publish_time: i64,
+}
+
+pub fn set_custom_oracle_price_permissionless(
+    ctx: Context<SetCustomOraclePricePermissionless>,
+    params: &SetCustomOraclePricePermissionlessParams,
+) -> Result<()> {
+    if params.publish_time <= ctx.accounts.oracle_account.publish_time {
+        msg!("Custom oracle price did not update because the requested publish time is stale.");
+        return Ok(());
+    }
+    // Get what should be the Ed25519Program signature verification instruction.
+    let signature_ix: Instruction =
+        sysvar::instructions::load_instruction_at_checked(0, &ctx.accounts.ix_sysvar)?;
+
+    validate_ed25519_signature_instruction(
+        &signature_ix,
+        &ctx.accounts.custody.oracle.oracle_authority,
+        params,
+    )?;
+
+    ctx.accounts.oracle_account.set(
+        params.price,
+        params.expo,
+        params.conf,
+        params.ema,
+        params.publish_time,
+    );
+    Ok(())
+}
+
+fn validate_ed25519_signature_instruction(
+    signature_ix: &Instruction,
+    expected_pubkey: &Pubkey,
+    expected_params: &SetCustomOraclePricePermissionlessParams,
+) -> Result<()> {
+    require_eq!(
+        signature_ix.program_id,
+        ed25519_program::ID,
+        PerpetualsError::PermissionlessOracleMissingSignature
+    );
+    require!(
+        signature_ix.accounts.is_empty() /* no accounts touched */
+            && signature_ix.data[0] == 0x01 /* only one ed25519 signature */
+            && signature_ix.data.len() == 180, /* data len matches exactly the expected */
+        PerpetualsError::PermissionlessOracleMalformedEd25519Data
+    );
+
+    // Manually access offsets for signer pubkey and message data according to:
+    // https://docs.solana.com/developing/runtime-facilities/programs#ed25519-program
+    let signer_pubkey = &signature_ix.data[16..16 + 32];
+    let mut verified_message = &signature_ix.data[112..];
+
+    let deserialized_instruction_params =
+        SetCustomOraclePricePermissionlessParams::deserialize(&mut verified_message)?;
+
+    require!(
+        signer_pubkey == expected_pubkey.to_bytes(),
+        PerpetualsError::PermissionlessOracleSignerMismatch
+    );
+    require!(
+        deserialized_instruction_params == *expected_params,
+        PerpetualsError::PermissionlessOracleMessageMismatch
+    );
+    Ok(())
+}

--- a/programs/perpetuals/src/lib.rs
+++ b/programs/perpetuals/src/lib.rs
@@ -238,4 +238,13 @@ pub mod perpetuals {
     ) -> Result<u64> {
         instructions::get_lp_token_price(ctx, &params)
     }
+
+    // This instruction must be part of a larger transaction where the **first** instruction
+    // is an ed25519 verification of the serialized oracle price update params.
+    pub fn set_custom_oracle_price_permissionless(
+        ctx: Context<SetCustomOraclePricePermissionless>,
+        params: SetCustomOraclePricePermissionlessParams,
+    ) -> Result<()> {
+        instructions::set_custom_oracle_price_permissionless(ctx, &params)
+    }
 }

--- a/programs/perpetuals/src/state/oracle.rs
+++ b/programs/perpetuals/src/state/oracle.rs
@@ -33,6 +33,8 @@ pub struct OraclePrice {
 pub struct OracleParams {
     pub oracle_account: Pubkey,
     pub oracle_type: OracleType,
+    // The oracle_authority pubkey is allowed to sign permissionless off-chain price updates.
+    pub oracle_authority: Pubkey,
     pub max_price_error: u64,
     pub max_price_age_sec: u32,
 }
@@ -49,6 +51,14 @@ pub struct CustomOracle {
 
 impl CustomOracle {
     pub const LEN: usize = 8 + std::mem::size_of::<CustomOracle>();
+
+    pub fn set(&mut self, price: u64, expo: i32, conf: u64, ema: u64, publish_time: i64) {
+        self.price = price;
+        self.expo = expo;
+        self.conf = conf;
+        self.ema = ema;
+        self.publish_time = publish_time;
+    }
 }
 
 impl PartialOrd for OraclePrice {

--- a/programs/perpetuals/src/state/pool.rs
+++ b/programs/perpetuals/src/state/pool.rs
@@ -1144,6 +1144,7 @@ mod test {
         let oracle = OracleParams {
             oracle_account: Pubkey::default(),
             oracle_type: OracleType::Custom,
+            oracle_authority: Pubkey::default(),
             max_price_error: 100,
             max_price_age_sec: 1,
         };

--- a/programs/perpetuals/tests/native/utils/fixtures.rs
+++ b/programs/perpetuals/tests/native/utils/fixtures.rs
@@ -75,6 +75,7 @@ pub fn oracle_params_regular(oracle_account: Pubkey) -> OracleParams {
     OracleParams {
         oracle_account,
         oracle_type: OracleType::Custom,
+        oracle_authority: Pubkey::default(),
         max_price_error: 1_000_000,
         max_price_age_sec: 30,
     }

--- a/programs/perpetuals/tests/native/utils/test_setup.rs
+++ b/programs/perpetuals/tests/native/utils/test_setup.rs
@@ -205,14 +205,10 @@ impl TestSetup {
 
         // Initialize users token accounts for each mints
         {
-            let mints_pubkeys: Vec<Pubkey> =
-                mints.values().into_iter().map(|info| info.pubkey).collect();
+            let mints_pubkeys: Vec<Pubkey> = mints.values().map(|info| info.pubkey).collect();
 
-            let users_pubkeys: Vec<Pubkey> = users
-                .values()
-                .into_iter()
-                .map(|keypair| keypair.pubkey())
-                .collect();
+            let users_pubkeys: Vec<Pubkey> =
+                users.values().map(|keypair| keypair.pubkey()).collect();
 
             utils::initialize_users_token_accounts(&program_test_ctx, mints_pubkeys, users_pubkeys)
                 .await;
@@ -355,11 +351,8 @@ impl TestSetup {
 
         // Initialize users token accounts for lp token mint
         {
-            let users_pubkeys: Vec<Pubkey> = users
-                .values()
-                .into_iter()
-                .map(|keypair| keypair.pubkey())
-                .collect();
+            let users_pubkeys: Vec<Pubkey> =
+                users.values().map(|keypair| keypair.pubkey()).collect();
 
             utils::initialize_users_token_accounts(
                 &program_test_ctx,

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -6,4 +6,4 @@ module.exports = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
-}
+};


### PR DESCRIPTION
This feature saves operational costs for the program authority.

Rather than the authority having to post frequent on chain price oracle updates, the user can post the oracle price update at the time of their transaction.

The authority hosts a backend service that the user can query to obtain a fresh price update payload signed by the authority. The user then includes this payload in their transaction.


Compute cost for just `SetCustomOraclePricePermissionless` is 22k.  The ed25519 program cost is not showing up in the logs for some reason, but overall budget is showing as 400k instead of 200k.
<img width="1720" alt="Screenshot 2023-10-13 at 7 49 32 AM" src="https://github.com/solana-labs/perpetuals/assets/1387955/5aec60a7-5329-4aa3-a37b-e96e1a38830e">
