### PR TITLE
Fix open/close position accounting

### DIFF
--- a/programs/perpetuals/tests/native/instructions/test_close_position.rs
+++ b/programs/perpetuals/tests/native/instructions/test_close_position.rs
@@ -2,7 +2,10 @@ use {
     super::get_update_pool_ix,
     crate::utils::{self, pda},
     anchor_lang::{prelude::Pubkey, ToAccountMetas},
-    perpetuals::{instructions::ClosePositionParams, state::custody::Custody},
+    perpetuals::{
+        instructions::ClosePositionParams,
+        state::{custody::Custody, position::Position},
+    },
     solana_program_test::{BanksClientError, ProgramTestContext},
     solana_sdk::signer::{keypair::Keypair, Signer},
     tokio::sync::RwLock,
@@ -12,32 +15,33 @@ pub async fn test_close_position(
     program_test_ctx: &RwLock<ProgramTestContext>,
     owner: &Keypair,
     payer: &Keypair,
-    pool_pda: &Pubkey,
-    custody_token_mint: &Pubkey,
     position_pda: &Pubkey,
     params: ClosePositionParams,
 ) -> std::result::Result<(), BanksClientError> {
     // ==== WHEN ==============================================================
+    let position_account = utils::get_account::<Position>(program_test_ctx, *position_pda).await;
+    let custody_pda = position_account.custody;
+    let collateral_custody_pda = position_account.collateral_custody;
+
+    let collateral_custody_account =
+        utils::get_account::<Custody>(program_test_ctx, collateral_custody_pda).await;
 
     // Prepare PDA and addresses
     let transfer_authority_pda = pda::get_transfer_authority_pda().0;
-    let perpetuals_pda = pda::get_perpetuals_pda().0;
-    let custody_pda = pda::get_custody_pda(pool_pda, custody_token_mint).0;
-    let custody_token_account_pda =
-        pda::get_custody_token_account_pda(pool_pda, custody_token_mint).0;
+    let perpetuals_pda: Pubkey = pda::get_perpetuals_pda().0;
+    let collateral_custody_token_account = pda::get_custody_token_account_pda(
+        &position_account.pool,
+        &collateral_custody_account.mint,
+    )
+    .0;
 
     let receiving_account_address =
-        utils::find_associated_token_account(&owner.pubkey(), custody_token_mint).0;
+        utils::find_associated_token_account(&owner.pubkey(), &collateral_custody_account.mint).0;
 
     let custody_account = utils::get_account::<Custody>(program_test_ctx, custody_pda).await;
     let custody_oracle_account_address = custody_account.oracle.oracle_account;
-
-    // Save account state before tx execution
-    let owner_receiving_account_before =
-        utils::get_token_account(program_test_ctx, receiving_account_address).await;
-
-    let custody_token_account_before =
-        utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
+    let collateral_custody_oracle_account_address =
+        collateral_custody_account.oracle.oracle_account;
 
     utils::create_and_execute_perpetuals_ix(
         program_test_ctx,
@@ -46,35 +50,25 @@ pub async fn test_close_position(
             receiving_account: receiving_account_address,
             transfer_authority: transfer_authority_pda,
             perpetuals: perpetuals_pda,
-            pool: *pool_pda,
+            pool: position_account.pool,
             position: *position_pda,
             custody: custody_pda,
             custody_oracle_account: custody_oracle_account_address,
-            collateral_custody: custody_pda,
-            collateral_custody_oracle_account: custody_oracle_account_address,
-            collateral_custody_token_account: custody_token_account_pda,
+            collateral_custody: collateral_custody_pda,
+            collateral_custody_oracle_account: collateral_custody_oracle_account_address,
+            collateral_custody_token_account,
             token_program: anchor_spl::token::ID,
         }
         .to_account_metas(None),
         perpetuals::instruction::ClosePosition { params },
         Some(&payer.pubkey()),
         &[owner, payer],
-        Some(get_update_pool_ix(program_test_ctx, payer, pool_pda).await?),
-        Some(get_update_pool_ix(program_test_ctx, payer, pool_pda).await?),
+        Some(get_update_pool_ix(program_test_ctx, payer, &position_account.pool).await?),
+        Some(get_update_pool_ix(program_test_ctx, payer, &position_account.pool).await?),
     )
     .await?;
 
     // ==== THEN ==============================================================
-    // Check the balance change
-    {
-        let owner_receiving_account_after =
-            utils::get_token_account(program_test_ctx, receiving_account_address).await;
-        let custody_token_account_after =
-            utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
-
-        assert!(owner_receiving_account_after.amount > owner_receiving_account_before.amount);
-        assert!(custody_token_account_after.amount < custody_token_account_before.amount);
-    }
 
     Ok(())
 }

--- a/programs/perpetuals/tests/native/instructions/test_open_position.rs
+++ b/programs/perpetuals/tests/native/instructions/test_open_position.rs
@@ -17,31 +17,56 @@ pub async fn test_open_position(
     payer: &Keypair,
     pool_pda: &Pubkey,
     custody_token_mint: &Pubkey,
+    collateral_custody_token_mint: Option<&Pubkey>,
     params: OpenPositionParams,
 ) -> std::result::Result<(solana_sdk::pubkey::Pubkey, u8), BanksClientError> {
     // ==== WHEN ==============================================================
 
-    // Prepare PDA and addresses
     let transfer_authority_pda = pda::get_transfer_authority_pda().0;
     let perpetuals_pda = pda::get_perpetuals_pda().0;
     let custody_pda = pda::get_custody_pda(pool_pda, custody_token_mint).0;
+
+    let collateral_custody_pda = if collateral_custody_token_mint.is_some() {
+        pda::get_custody_pda(pool_pda, collateral_custody_token_mint.unwrap()).0
+    } else {
+        custody_pda
+    };
+
     let custody_token_account_pda =
         pda::get_custody_token_account_pda(pool_pda, custody_token_mint).0;
+
+    let collateral_custody_token_account_pda = if collateral_custody_token_mint.is_some() {
+        pda::get_custody_token_account_pda(pool_pda, collateral_custody_token_mint.unwrap()).0
+    } else {
+        custody_token_account_pda
+    };
+
+    let funding_account_address = if collateral_custody_token_mint.is_some() {
+        utils::find_associated_token_account(
+            &owner.pubkey(),
+            collateral_custody_token_mint.unwrap(),
+        )
+        .0
+    } else {
+        utils::find_associated_token_account(&owner.pubkey(), custody_token_mint).0
+    };
 
     let (position_pda, position_bump) =
         pda::get_position_pda(&owner.pubkey(), pool_pda, &custody_pda, params.side);
 
-    let funding_account_address =
-        utils::find_associated_token_account(&owner.pubkey(), custody_token_mint).0;
-
     let custody_account = utils::get_account::<Custody>(program_test_ctx, custody_pda).await;
     let custody_oracle_account_address = custody_account.oracle.oracle_account;
+
+    let collateral_custody_account =
+        utils::get_account::<Custody>(program_test_ctx, collateral_custody_pda).await;
+    let collateral_custody_oracle_account_address =
+        collateral_custody_account.oracle.oracle_account;
 
     // Save account state before tx execution
     let owner_funding_account_before =
         utils::get_token_account(program_test_ctx, funding_account_address).await;
-    let custody_token_account_before =
-        utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
+    let collateral_custody_token_account_before =
+        utils::get_token_account(program_test_ctx, collateral_custody_token_account_pda).await;
 
     utils::create_and_execute_perpetuals_ix(
         program_test_ctx,
@@ -54,9 +79,9 @@ pub async fn test_open_position(
             position: position_pda,
             custody: custody_pda,
             custody_oracle_account: custody_oracle_account_address,
-            collateral_custody: custody_pda,
-            collateral_custody_oracle_account: custody_oracle_account_address,
-            collateral_custody_token_account: custody_token_account_pda,
+            collateral_custody: collateral_custody_pda,
+            collateral_custody_oracle_account: collateral_custody_oracle_account_address,
+            collateral_custody_token_account: collateral_custody_token_account_pda,
             system_program: anchor_lang::system_program::ID,
             token_program: anchor_spl::token::ID,
         }
@@ -74,11 +99,14 @@ pub async fn test_open_position(
     {
         let owner_funding_account_after =
             utils::get_token_account(program_test_ctx, funding_account_address).await;
-        let custody_token_account_after =
-            utils::get_token_account(program_test_ctx, custody_token_account_pda).await;
+        let collateral_custody_token_account_after =
+            utils::get_token_account(program_test_ctx, collateral_custody_token_account_pda).await;
 
         assert!(owner_funding_account_after.amount < owner_funding_account_before.amount);
-        assert!(custody_token_account_after.amount > custody_token_account_before.amount);
+        assert!(
+            collateral_custody_token_account_after.amount
+                > collateral_custody_token_account_before.amount
+        );
     }
 
     // Check the position
@@ -100,6 +128,5 @@ pub async fn test_open_position(
         assert_eq!(position_account.collateral_amount, params.collateral);
         assert_eq!(position_account.bump, position_bump);
     }
-
     Ok((position_pda, position_bump))
 }

--- a/programs/perpetuals/tests/native/main.rs
+++ b/programs/perpetuals/tests/native/main.rs
@@ -15,6 +15,8 @@ pub async fn test_integration() {
     tests_suite::position::min_max_leverage().await;
     tests_suite::position::liquidate_position().await;
     tests_suite::position::max_user_profit().await;
+    tests_suite::position::open_and_close_long_position_accounting().await;
+    tests_suite::position::open_and_close_short_position_accounting().await;
 
     tests_suite::lp_token::lp_token_price().await;
 }

--- a/programs/perpetuals/tests/native/tests_suite/basic_interactions.rs
+++ b/programs/perpetuals/tests/native/tests_suite/basic_interactions.rs
@@ -106,6 +106,7 @@ pub async fn basic_interactions() {
             &test_setup.payer_keypair,
             &test_setup.pool_pda,
             eth_mint,
+            None,
             OpenPositionParams {
                 // max price paid (slippage implied)
                 price: utils::scale(1_550, USDC_DECIMALS),
@@ -123,8 +124,6 @@ pub async fn basic_interactions() {
             &test_setup.program_test_ctx,
             martin,
             &test_setup.payer_keypair,
-            &test_setup.pool_pda,
-            eth_mint,
             &position_pda,
             ClosePositionParams {
                 // lowest exit price paid (slippage implied)

--- a/programs/perpetuals/tests/native/tests_suite/position/liquidate_position.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/liquidate_position.rs
@@ -108,6 +108,7 @@ pub async fn liquidate_position() {
         &test_setup.payer_keypair,
         &test_setup.pool_pda,
         eth_mint,
+        None,
         OpenPositionParams {
             // max price paid (slippage implied)
             price: utils::scale(1_550, ETH_DECIMALS),

--- a/programs/perpetuals/tests/native/tests_suite/position/max_user_profit.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/max_user_profit.rs
@@ -102,6 +102,7 @@ pub async fn max_user_profit() {
         &test_setup.payer_keypair,
         &test_setup.pool_pda,
         eth_mint,
+        None,
         OpenPositionParams {
             // max price paid (slippage implied)
             price: utils::scale(1_550, ETH_DECIMALS),
@@ -147,8 +148,6 @@ pub async fn max_user_profit() {
         &test_setup.program_test_ctx,
         martin,
         &test_setup.payer_keypair,
-        &test_setup.pool_pda,
-        eth_mint,
         &position_pda,
         ClosePositionParams {
             // lowest exit price paid (slippage implied)

--- a/programs/perpetuals/tests/native/tests_suite/position/min_max_leverage.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/min_max_leverage.rs
@@ -100,6 +100,7 @@ pub async fn min_max_leverage() {
         &test_setup.payer_keypair,
         &test_setup.pool_pda,
         eth_mint,
+        None,
         OpenPositionParams {
             // max price paid (slippage implied)
             price: utils::scale(1_550, ETH_DECIMALS),
@@ -118,6 +119,7 @@ pub async fn min_max_leverage() {
         &test_setup.payer_keypair,
         &test_setup.pool_pda,
         eth_mint,
+        None,
         OpenPositionParams {
             // max price paid (slippage implied)
             price: utils::scale(1_550, ETH_DECIMALS),

--- a/programs/perpetuals/tests/native/tests_suite/position/mod.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/mod.rs
@@ -1,5 +1,10 @@
 pub mod liquidate_position;
 pub mod max_user_profit;
 pub mod min_max_leverage;
+pub mod open_and_close_long_position_accounting;
+pub mod open_and_close_short_position_accounting;
 
-pub use {liquidate_position::*, max_user_profit::*, min_max_leverage::*};
+pub use {
+    liquidate_position::*, max_user_profit::*, min_max_leverage::*,
+    open_and_close_long_position_accounting::*, open_and_close_short_position_accounting::*,
+};

--- a/programs/perpetuals/tests/native/tests_suite/position/open_and_close_long_position_accounting.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/open_and_close_long_position_accounting.rs
@@ -1,0 +1,490 @@
+use {
+    crate::{
+        assert_unchanged,
+        instructions::{test_close_position, test_open_position, test_set_custom_oracle_price},
+        utils,
+    },
+    maplit::hashmap,
+    perpetuals::{
+        instructions::{ClosePositionParams, OpenPositionParams, SetCustomOraclePriceParams},
+        state::{
+            custody::{Custody, PricingParams},
+            perpetuals::Perpetuals,
+            position::{Position, Side},
+        },
+    },
+    solana_sdk::signer::Signer,
+};
+
+const ETH_DECIMALS: u8 = 9;
+const USDC_DECIMALS: u8 = 6;
+
+#[allow(deprecated)]
+pub async fn open_and_close_long_position_accounting() {
+    let test_setup = utils::TestSetup::new(
+        vec![
+            utils::UserParam {
+                name: "alice",
+                token_balances: hashmap! {
+                    "usdc" => utils::scale(150_000, USDC_DECIMALS),
+                    "eth" => utils::scale(100, ETH_DECIMALS),
+                },
+            },
+            utils::UserParam {
+                name: "martin",
+                token_balances: hashmap! {
+                    "usdc" => utils::scale(150_000, USDC_DECIMALS),
+                    "eth" => utils::scale(100, ETH_DECIMALS),
+                },
+            },
+        ],
+        vec![
+            utils::MintParam {
+                name: "usdc",
+                decimals: USDC_DECIMALS,
+            },
+            utils::MintParam {
+                name: "eth",
+                decimals: ETH_DECIMALS,
+            },
+        ],
+        vec!["admin_a", "admin_b", "admin_c"],
+        "main_pool",
+        vec![
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "usdc",
+                    is_stable: true,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(50.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1, USDC_DECIMALS),
+                    initial_conf: utils::scale_f64(0.01, USDC_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(150_000, USDC_DECIMALS),
+                payer_user_name: "alice",
+            },
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "eth",
+                    is_stable: false,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(100.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1_500, ETH_DECIMALS),
+                    initial_conf: utils::scale(10, ETH_DECIMALS),
+                    pricing_params: Some(PricingParams {
+                        // Expressed in BPS, with BPS = 10_000
+                        // 50_000 = x5, 100_000 = x10
+                        max_leverage: 100_000,
+                        ..utils::fixtures::pricing_params_regular(false)
+                    }),
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(100, ETH_DECIMALS),
+                payer_user_name: "alice",
+            },
+        ],
+    )
+    .await;
+
+    let martin = test_setup.get_user_keypair_by_name("martin");
+
+    let admin_a = test_setup.get_multisig_member_keypair_by_name("admin_a");
+
+    let multisig_signers = test_setup.get_multisig_signers();
+
+    let eth_mint = &test_setup.get_mint_by_name("eth");
+
+    let martin_eth_ata =
+        utils::find_associated_token_account(&martin.try_pubkey().unwrap(), eth_mint).0;
+
+    let eth_custody_pda = test_setup.custodies_info[1].custody_pda;
+
+    let eth_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+
+    let martin_eth_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+    // Martin: Open 1 ETH long position x5
+    let position_pda = test_open_position(
+        &test_setup.program_test_ctx,
+        martin,
+        &test_setup.payer_keypair,
+        &test_setup.pool_pda,
+        eth_mint,
+        None,
+        OpenPositionParams {
+            // max price paid (slippage implied)
+            price: utils::scale(1_550, Perpetuals::USD_DECIMALS),
+            collateral: utils::scale(1, ETH_DECIMALS),
+            size: utils::scale(5, ETH_DECIMALS),
+            side: Side::Long,
+        },
+    )
+    .await
+    .unwrap()
+    .0;
+
+    {
+        let eth_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+        let martin_eth_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+        // Check user balance
+        {
+            assert_eq!(
+                // Paid 1 ETH as collateral and 0.05 ETH as fees
+                martin_eth_ata_balance_before - 1_050_000_000,
+                martin_eth_ata_balance_after
+            );
+        }
+
+        // Check the position PDA info
+        {
+            let position =
+                utils::get_account::<Position>(&test_setup.program_test_ctx, position_pda).await;
+
+            assert_eq!(position.side, Side::Long);
+            // entry price
+            // price of the token + trade_spread_long (in BPS)
+            assert_eq!(position.price, 1_515_000_000);
+            // locked amount * position price (entry price)
+            assert_eq!(position.size_usd, 7_575_000_000);
+            assert_eq!(position.borrow_size_usd, 7_575_000_000);
+            // 1 ETH at price
+            assert_eq!(position.collateral_usd, 1_500_000_000);
+            // 1 ETH
+            assert_eq!(position.collateral_amount, 1_000_000_000);
+            assert_eq!(position.unrealized_profit_usd, 0);
+            assert_eq!(position.unrealized_loss_usd, 0);
+            assert_eq!(position.cumulative_interest_snapshot, 0);
+            // 5 ETH
+            assert_eq!(position.locked_amount, 5_000_000_000);
+        }
+
+        // Double check effect of opening position on ETH custody accounting
+        {
+            // Collected fees
+            {
+                let before = &eth_custody_account_before.collected_fees;
+                let after = &eth_custody_account_after.collected_fees;
+
+                assert_eq!(
+                    before.open_position_usd + 75_000_000,
+                    after.open_position_usd
+                );
+
+                assert_unchanged!(before.swap_usd, after.swap_usd);
+                assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+            }
+
+            // Volume stats
+            {
+                let before = &eth_custody_account_before.volume_stats;
+                let after = &eth_custody_account_after.volume_stats;
+
+                assert_eq!(
+                    before.open_position_usd + 7_575_000_000,
+                    after.open_position_usd
+                );
+
+                assert_unchanged!(before.swap_usd, after.swap_usd);
+                assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+            }
+
+            // Trade Stats
+            {
+                let before = &eth_custody_account_before.trade_stats;
+                let after = &eth_custody_account_after.trade_stats;
+
+                assert_eq!(before.oi_long_usd + 7_575_000_000, after.oi_long_usd);
+
+                assert_unchanged!(before.profit_usd, after.profit_usd);
+                assert_unchanged!(before.loss_usd, after.loss_usd);
+                assert_unchanged!(before.oi_short_usd, after.oi_short_usd);
+            }
+
+            // Long positions
+            {
+                let before = &eth_custody_account_before.long_positions;
+                let after = &eth_custody_account_after.long_positions;
+
+                assert_eq!(before.open_positions + 1, after.open_positions);
+
+                assert_eq!(before.size_usd + 7_575_000_000, after.size_usd);
+
+                assert_eq!(
+                    before.borrow_size_usd + 7_575_000_000,
+                    after.borrow_size_usd
+                );
+
+                assert_eq!(
+                    // 5 ETH
+                    before.locked_amount + 5_000_000_000,
+                    after.locked_amount
+                );
+
+                assert_eq!(before.total_quantity + 50_000, after.total_quantity);
+
+                // WeightedPrice = position_price * quantity
+                assert_eq!(
+                    before.weighted_price + 75_750_000_000_000,
+                    after.weighted_price
+                );
+
+                // Should probably change, mark the parameter as deprecated
+                assert_unchanged!(before.collateral_usd, after.collateral_usd);
+
+                assert_unchanged!(
+                    before.cumulative_interest_usd,
+                    after.cumulative_interest_usd
+                );
+
+                assert_unchanged!(
+                    before.cumulative_interest_snapshot,
+                    after.cumulative_interest_snapshot
+                );
+            }
+
+            // Short positions
+            {
+                let before = &eth_custody_account_before.short_positions;
+                let after = &eth_custody_account_after.short_positions;
+
+                assert_unchanged!(before.open_positions, after.open_positions);
+                assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                assert_unchanged!(before.size_usd, after.size_usd);
+                assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                assert_unchanged!(before.locked_amount, after.locked_amount);
+                assert_unchanged!(before.weighted_price, after.weighted_price);
+                assert_unchanged!(before.total_quantity, after.total_quantity);
+                assert_unchanged!(
+                    before.cumulative_interest_usd,
+                    after.cumulative_interest_usd
+                );
+                assert_unchanged!(
+                    before.cumulative_interest_snapshot,
+                    after.cumulative_interest_snapshot
+                );
+            }
+        }
+    }
+
+    // Wait for 10 hours so we can see the borrow rate in action
+    utils::warp_forward(&test_setup.program_test_ctx, 36_000).await;
+
+    // Makes ETH price to drop 10%
+    {
+        let eth_test_oracle_pda = test_setup.custodies_info[1].custom_oracle_pda;
+        let eth_custody_pda = test_setup.custodies_info[1].custody_pda;
+
+        let publish_time = utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await;
+
+        test_set_custom_oracle_price(
+            &test_setup.program_test_ctx,
+            admin_a,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            &eth_custody_pda,
+            &eth_test_oracle_pda,
+            SetCustomOraclePriceParams {
+                price: utils::scale(1_350, ETH_DECIMALS),
+                expo: -(ETH_DECIMALS as i32),
+                conf: utils::scale(10, ETH_DECIMALS),
+                ema: utils::scale(1_350, ETH_DECIMALS),
+                publish_time,
+            },
+            &multisig_signers,
+        )
+        .await
+        .unwrap();
+    }
+
+    let eth_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+
+    let martin_eth_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+    // Martin: Close the ETH position
+    test_close_position(
+        &test_setup.program_test_ctx,
+        martin,
+        &test_setup.payer_keypair,
+        &position_pda,
+        ClosePositionParams {
+            // lower the price for slippage
+            price: utils::scale(1_330, Perpetuals::USD_DECIMALS),
+        },
+    )
+    .await
+    .unwrap();
+
+    {
+        let eth_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+        let martin_eth_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+        // Check user balance
+        {
+            // User provided 1 ETH at $1,500
+            // ETH lost 10% of value, and now worth $1,350
+            // User position was x5 leverage
+            // User lost (1,500-1,350)*5 = $750 in absolute value
+            //
+            // User is at $178,5 lost per ETH (price diff)
+            // entry_position_price - exit_price (both taking into account spread) & borrow
+            //
+            // Fees: $75,750001
+            // Total amount lost: $968.250016 (178,5 * 5 + 75,750001)
+            //
+            // User get back ~$531,74 worth of ETH (1,500 original value minus ~$968 loss)
+            assert_eq!(
+                martin_eth_ata_balance_before + 393_608_332,
+                martin_eth_ata_balance_after
+            );
+        }
+
+        // Double check effect of closing position on ETH custody accounting
+        {
+            // Collected fees
+            {
+                let before = &eth_custody_account_before.collected_fees;
+                let after = &eth_custody_account_after.collected_fees;
+
+                assert_eq!(
+                    before.close_position_usd + 75_750_001,
+                    after.close_position_usd
+                );
+
+                assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                assert_unchanged!(before.swap_usd, after.swap_usd);
+                assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+            }
+
+            // Volume stats
+            {
+                let before = &eth_custody_account_before.volume_stats;
+                let after = &eth_custody_account_after.volume_stats;
+
+                assert_eq!(
+                    // locked amount (size) * position price (entry price)
+                    before.close_position_usd + 7_575_000_000,
+                    after.close_position_usd
+                );
+
+                assert_unchanged!(before.swap_usd, before.swap_usd);
+                assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+            }
+
+            // Trade Stats
+            {
+                let before = &eth_custody_account_before.trade_stats;
+                let after = &eth_custody_account_after.trade_stats;
+
+                assert_eq!(
+                    // locked amount (size) * position price (entry price)
+                    before.oi_long_usd - 7_575_000_000,
+                    after.oi_long_usd
+                );
+
+                assert_eq!(before.loss_usd + 968_628_751, after.loss_usd);
+
+                assert_unchanged!(before.profit_usd, after.profit_usd);
+                assert_unchanged!(before.oi_short_usd, after.oi_short_usd);
+            }
+
+            // Long positions
+            {
+                let before = &eth_custody_account_before.long_positions;
+                let after = &eth_custody_account_after.long_positions;
+
+                assert_eq!(before.open_positions - 1, after.open_positions);
+
+                assert_eq!(
+                    // locked amount (size) * position price (entry price)
+                    before.size_usd - 7_575_000_000,
+                    after.size_usd
+                );
+
+                assert_eq!(
+                    // locked amount (size) * position price (entry price)
+                    before.borrow_size_usd - 7_575_000_000,
+                    after.borrow_size_usd
+                );
+
+                assert_eq!(
+                    // 5 ETH
+                    before.locked_amount - 5_000_000_000,
+                    after.locked_amount
+                );
+
+                assert_eq!(before.total_quantity - 50_000, after.total_quantity);
+
+                assert_eq!(
+                    before.weighted_price - 75_750_000_000_000,
+                    after.weighted_price
+                );
+
+                assert_unchanged!(
+                    before.cumulative_interest_snapshot,
+                    after.cumulative_interest_snapshot
+                );
+
+                assert_unchanged!(before.collateral_usd, after.collateral_usd);
+
+                assert_unchanged!(
+                    before.cumulative_interest_usd,
+                    after.cumulative_interest_usd
+                );
+            }
+
+            // Short positions
+            {
+                let before = &eth_custody_account_before.short_positions;
+                let after = &eth_custody_account_after.short_positions;
+
+                assert_unchanged!(before.open_positions, after.open_positions);
+                assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                assert_unchanged!(before.size_usd, after.size_usd);
+                assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                assert_unchanged!(before.locked_amount, after.locked_amount);
+                assert_unchanged!(before.weighted_price, after.weighted_price);
+                assert_unchanged!(before.total_quantity, after.total_quantity);
+
+                assert_unchanged!(
+                    before.cumulative_interest_usd,
+                    after.cumulative_interest_usd
+                );
+
+                assert_unchanged!(
+                    before.cumulative_interest_snapshot,
+                    after.cumulative_interest_snapshot
+                );
+            }
+        }
+    }
+}

--- a/programs/perpetuals/tests/native/tests_suite/position/open_and_close_short_position_accounting.rs
+++ b/programs/perpetuals/tests/native/tests_suite/position/open_and_close_short_position_accounting.rs
@@ -1,0 +1,676 @@
+use {
+    crate::{
+        assert_unchanged,
+        instructions::{test_close_position, test_open_position, test_set_custom_oracle_price},
+        utils,
+    },
+    maplit::hashmap,
+    perpetuals::{
+        instructions::{ClosePositionParams, OpenPositionParams, SetCustomOraclePriceParams},
+        state::{
+            custody::{Custody, PricingParams},
+            perpetuals::Perpetuals,
+            position::{Position, Side},
+        },
+    },
+    solana_sdk::signer::Signer,
+};
+
+const ETH_DECIMALS: u8 = 9;
+const USDC_DECIMALS: u8 = 6;
+
+#[allow(deprecated)]
+pub async fn open_and_close_short_position_accounting() {
+    let test_setup = utils::TestSetup::new(
+        vec![
+            utils::UserParam {
+                name: "alice",
+                token_balances: hashmap! {
+                    "usdc" => utils::scale(150_000, USDC_DECIMALS),
+                    "eth" => utils::scale(100, ETH_DECIMALS),
+                },
+            },
+            utils::UserParam {
+                name: "martin",
+                token_balances: hashmap! {
+                    "usdc" => utils::scale(150_000, USDC_DECIMALS),
+                    "eth" => utils::scale(100, ETH_DECIMALS),
+                },
+            },
+        ],
+        vec![
+            utils::MintParam {
+                name: "usdc",
+                decimals: USDC_DECIMALS,
+            },
+            utils::MintParam {
+                name: "eth",
+                decimals: ETH_DECIMALS,
+            },
+        ],
+        vec!["admin_a", "admin_b", "admin_c"],
+        "main_pool",
+        vec![
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "usdc",
+                    is_stable: true,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(50.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1, USDC_DECIMALS),
+                    initial_conf: utils::scale_f64(0.01, USDC_DECIMALS),
+                    pricing_params: None,
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(150_000, USDC_DECIMALS),
+                payer_user_name: "alice",
+            },
+            utils::SetupCustodyWithLiquidityParams {
+                setup_custody_params: utils::SetupCustodyParams {
+                    mint_name: "eth",
+                    is_stable: false,
+                    is_virtual: false,
+                    target_ratio: utils::ratio_from_percentage(100.0),
+                    min_ratio: utils::ratio_from_percentage(0.0),
+                    max_ratio: utils::ratio_from_percentage(100.0),
+                    initial_price: utils::scale(1_500, ETH_DECIMALS),
+                    initial_conf: utils::scale(10, ETH_DECIMALS),
+                    pricing_params: Some(PricingParams {
+                        // Expressed in BPS, with BPS = 10_000
+                        // 50_000 = x5, 100_000 = x10
+                        max_leverage: 100_000,
+                        ..utils::fixtures::pricing_params_regular(false)
+                    }),
+                    permissions: None,
+                    fees: None,
+                    borrow_rate: None,
+                },
+                liquidity_amount: utils::scale(100, ETH_DECIMALS),
+                payer_user_name: "alice",
+            },
+        ],
+    )
+    .await;
+
+    let martin = test_setup.get_user_keypair_by_name("martin");
+
+    let admin_a = test_setup.get_multisig_member_keypair_by_name("admin_a");
+
+    let multisig_signers = test_setup.get_multisig_signers();
+
+    let usdc_mint = &test_setup.get_mint_by_name("usdc");
+    let eth_mint = &test_setup.get_mint_by_name("eth");
+
+    let usdc_custody_pda = test_setup.custodies_info[0].custody_pda;
+    let eth_custody_pda = test_setup.custodies_info[1].custody_pda;
+
+    let martin_usdc_ata =
+        utils::find_associated_token_account(&martin.try_pubkey().unwrap(), usdc_mint).0;
+    let martin_eth_ata =
+        utils::find_associated_token_account(&martin.try_pubkey().unwrap(), eth_mint).0;
+
+    let eth_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+    let usdc_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, usdc_custody_pda).await;
+
+    let martin_usdc_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_usdc_ata).await;
+    let martin_eth_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+    // Martin: Open 1 ETH short with 500 USDC
+    let position_pda = test_open_position(
+        &test_setup.program_test_ctx,
+        martin,
+        &test_setup.payer_keypair,
+        &test_setup.pool_pda,
+        eth_mint,
+        Some(usdc_mint),
+        OpenPositionParams {
+            // max price paid (slippage implied)
+            price: utils::scale(1_400, Perpetuals::USD_DECIMALS),
+            collateral: utils::scale(500, USDC_DECIMALS),
+            size: utils::scale(1, ETH_DECIMALS),
+            side: Side::Short,
+        },
+    )
+    .await
+    .unwrap()
+    .0;
+
+    // See impact of opening a new position
+    {
+        let eth_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+        let usdc_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, usdc_custody_pda).await;
+
+        let martin_usdc_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_usdc_ata).await;
+        let martin_eth_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+        // Check user balance
+        {
+            // USDC
+            assert_eq!(
+                // Paid 500 USDC as collateral + 15 USDC as fees
+                martin_usdc_ata_balance_before - 515_000_000,
+                martin_usdc_ata_balance_after
+            );
+
+            // ETH
+            assert_unchanged!(martin_eth_ata_balance_before, martin_eth_ata_balance_after);
+        }
+
+        // Check the position PDA info
+        {
+            let position =
+                utils::get_account::<Position>(&test_setup.program_test_ctx, position_pda).await;
+
+            assert_eq!(position.side, Side::Short);
+            // entry price
+            assert_eq!(position.price, 1_485_000_000);
+            assert_eq!(position.size_usd, 1_485_000_000);
+            assert_eq!(position.borrow_size_usd, 1_485_000_000);
+            assert_eq!(position.collateral_usd, 500_000_000);
+            assert_eq!(position.collateral_amount, 500_000_000);
+            assert_eq!(position.unrealized_profit_usd, 0);
+            assert_eq!(position.unrealized_loss_usd, 0);
+            assert_eq!(position.cumulative_interest_snapshot, 0);
+
+            // Locked amount in USDC
+            assert_eq!(position.locked_amount, 1_485_000_000);
+        }
+
+        // Double check effect of opening position on ETH/USDC custody accounting
+        {
+            // Collected fees
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.collected_fees;
+                    let after = &eth_custody_account_after.collected_fees;
+
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.collected_fees;
+                    let after = &usdc_custody_account_after.collected_fees;
+
+                    assert_eq!(
+                        before.open_position_usd + 15_000_000,
+                        after.open_position_usd
+                    );
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+            }
+
+            // Volume stats
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.volume_stats;
+                    let after = &eth_custody_account_after.volume_stats;
+
+                    assert_eq!(
+                        before.open_position_usd + 1_485_000_000,
+                        after.open_position_usd
+                    );
+
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.volume_stats;
+                    let after = &usdc_custody_account_after.volume_stats;
+
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+            }
+
+            // Trade Stats
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.trade_stats;
+                    let after = &eth_custody_account_after.trade_stats;
+
+                    assert_eq!(before.oi_short_usd + 1_485_000_000, after.oi_short_usd);
+
+                    assert_unchanged!(before.oi_long_usd, after.oi_long_usd);
+                    assert_unchanged!(before.profit_usd, after.profit_usd);
+                    assert_unchanged!(before.loss_usd, after.loss_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.trade_stats;
+                    let after = &usdc_custody_account_after.trade_stats;
+
+                    assert_unchanged!(before.oi_short_usd, after.oi_short_usd);
+                    assert_unchanged!(before.oi_long_usd, after.oi_long_usd);
+                    assert_unchanged!(before.profit_usd, after.profit_usd);
+                    assert_unchanged!(before.loss_usd, after.loss_usd);
+                }
+            }
+
+            // Long positions
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.long_positions;
+                    let after = &eth_custody_account_after.long_positions;
+
+                    assert_unchanged!(before.open_positions, after.open_positions);
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.long_positions;
+                    let after = &usdc_custody_account_after.long_positions;
+
+                    assert_unchanged!(before.open_positions, after.open_positions);
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+            }
+
+            // Short positions
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.short_positions;
+                    let after = &eth_custody_account_after.short_positions;
+
+                    assert_eq!(before.open_positions + 1, after.open_positions);
+                    assert_eq!(before.size_usd + 1_485_000_000, after.size_usd);
+                    assert_eq!(before.total_quantity + 10_000, after.total_quantity);
+
+                    assert_eq!(
+                        before.weighted_price + 14_850_000_000_000,
+                        after.weighted_price
+                    );
+
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.short_positions;
+                    let after = &usdc_custody_account_after.short_positions;
+
+                    assert_eq!(before.open_positions + 1, after.open_positions);
+                    assert_eq!(before.borrow_size_usd + 1485_000_000, after.borrow_size_usd);
+                    assert_eq!(before.locked_amount + 1_485_000_000, after.locked_amount);
+
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+            }
+        }
+    }
+
+    // Wait for 10 hours so we can see the borrow rate in action
+    utils::warp_forward(&test_setup.program_test_ctx, 36_000).await;
+
+    // Makes ETH price to drop 10%
+    {
+        let eth_test_oracle_pda = test_setup.custodies_info[1].custom_oracle_pda;
+        let eth_custody_pda = test_setup.custodies_info[1].custody_pda;
+
+        let publish_time = utils::get_current_unix_timestamp(&test_setup.program_test_ctx).await;
+
+        test_set_custom_oracle_price(
+            &test_setup.program_test_ctx,
+            admin_a,
+            &test_setup.payer_keypair,
+            &test_setup.pool_pda,
+            &eth_custody_pda,
+            &eth_test_oracle_pda,
+            SetCustomOraclePriceParams {
+                price: utils::scale(1_350, ETH_DECIMALS),
+                expo: -(ETH_DECIMALS as i32),
+                conf: utils::scale(10, ETH_DECIMALS),
+                ema: utils::scale(1_350, ETH_DECIMALS),
+                publish_time,
+            },
+            &multisig_signers,
+        )
+        .await
+        .unwrap();
+    }
+
+    let eth_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+    let usdc_custody_account_before =
+        utils::get_account::<Custody>(&test_setup.program_test_ctx, usdc_custody_pda).await;
+
+    let martin_usdc_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_usdc_ata).await;
+    let martin_eth_ata_balance_before =
+        utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+    // Martin: Close the ETH position
+    test_close_position(
+        &test_setup.program_test_ctx,
+        martin,
+        &test_setup.payer_keypair,
+        &position_pda,
+        ClosePositionParams {
+            // increase the price for slippage
+            price: utils::scale(1_370, Perpetuals::USD_DECIMALS),
+        },
+    )
+    .await
+    .unwrap();
+
+    {
+        let eth_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, eth_custody_pda).await;
+        let usdc_custody_account_after =
+            utils::get_account::<Custody>(&test_setup.program_test_ctx, usdc_custody_pda).await;
+
+        let martin_usdc_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_usdc_ata).await;
+        let martin_eth_ata_balance_after =
+            utils::get_token_account_balance(&test_setup.program_test_ctx, martin_eth_ata).await;
+
+        // Check user balance
+        {
+            // USDC
+            assert_eq!(
+                // User getting 106.649999 USDC of profit
+                //
+                // ETH priced dropped of 10%
+                // theorically $150 of profit for user (without spread and fees)
+                //
+                // user getting $121,5
+                // exit_price - entry_position_price (both taking into account spread) & borrow
+                //
+                // Fees: $14.85
+                // Total amount earned: $106.649999
+                martin_usdc_ata_balance_before + 606_635_299,
+                martin_usdc_ata_balance_after
+            );
+
+            // ETH
+            assert_unchanged!(martin_eth_ata_balance_before, martin_eth_ata_balance_after);
+        }
+
+        // Double check effect of closing position on ETH custody accounting
+        {
+            // Collected fees
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.collected_fees;
+                    let after = &eth_custody_account_after.collected_fees;
+
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.collected_fees;
+                    let after = &usdc_custody_account_after.collected_fees;
+
+                    assert_eq!(
+                        before.close_position_usd + 14_850_000,
+                        after.close_position_usd
+                    );
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.swap_usd, after.swap_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+            }
+
+            // Volume stats
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.volume_stats;
+                    let after = &eth_custody_account_after.volume_stats;
+
+                    assert_eq!(
+                        before.close_position_usd + 1_485_000_000,
+                        after.close_position_usd
+                    );
+
+                    assert_unchanged!(before.swap_usd, before.swap_usd);
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.volume_stats;
+                    let after = &usdc_custody_account_after.volume_stats;
+
+                    assert_unchanged!(before.close_position_usd, after.close_position_usd);
+                    assert_unchanged!(before.swap_usd, before.swap_usd);
+                    assert_unchanged!(before.open_position_usd, after.open_position_usd);
+                    assert_unchanged!(before.add_liquidity_usd, after.add_liquidity_usd);
+                    assert_unchanged!(before.remove_liquidity_usd, after.remove_liquidity_usd);
+                    assert_unchanged!(before.liquidation_usd, after.liquidation_usd);
+                }
+            }
+
+            // Trade Stats
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.trade_stats;
+                    let after = &eth_custody_account_after.trade_stats;
+
+                    assert_unchanged!(before.oi_long_usd, after.oi_long_usd);
+                    assert_unchanged!(before.loss_usd, after.loss_usd);
+
+                    assert_eq!(before.oi_short_usd - 1_485_000_000, after.oi_short_usd);
+                    assert_eq!(before.profit_usd + 106_635_299, after.profit_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.trade_stats;
+                    let after = &usdc_custody_account_after.trade_stats;
+
+                    assert_unchanged!(before.oi_long_usd, after.oi_long_usd);
+                    assert_unchanged!(before.loss_usd, after.loss_usd);
+                    assert_unchanged!(before.oi_short_usd, after.oi_short_usd);
+                    assert_unchanged!(before.profit_usd, after.profit_usd);
+                }
+            }
+
+            // Long positions
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.long_positions;
+                    let after = &eth_custody_account_after.long_positions;
+
+                    assert_unchanged!(before.open_positions, after.open_positions);
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.long_positions;
+                    let after = &usdc_custody_account_after.long_positions;
+
+                    assert_unchanged!(before.open_positions, after.open_positions);
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+                }
+            }
+
+            // Short positions
+            {
+                // ETH
+                {
+                    let before = &eth_custody_account_before.short_positions;
+                    let after = &eth_custody_account_after.short_positions;
+
+                    assert_eq!(before.open_positions - 1, after.open_positions);
+                    assert_eq!(before.size_usd - 1_485_000_000, after.size_usd);
+                    assert_eq!(
+                        before.weighted_price - 14_850_000_000_000,
+                        after.weighted_price
+                    );
+                    assert_eq!(before.total_quantity - 10_000, after.total_quantity);
+
+                    assert_unchanged!(before.borrow_size_usd, after.borrow_size_usd);
+                    assert_unchanged!(before.locked_amount, after.locked_amount);
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                }
+
+                // USDC
+                {
+                    let before = &usdc_custody_account_before.short_positions;
+                    let after = &usdc_custody_account_after.short_positions;
+
+                    assert_eq!(before.open_positions - 1, after.open_positions);
+                    assert_eq!(
+                        before.borrow_size_usd - 1_485_000_000,
+                        after.borrow_size_usd
+                    );
+                    assert_eq!(before.locked_amount - 1_485_000_000, after.locked_amount);
+
+                    assert_unchanged!(before.size_usd, after.size_usd);
+                    assert_unchanged!(before.weighted_price, after.weighted_price);
+                    assert_unchanged!(before.total_quantity, after.total_quantity);
+
+                    assert_unchanged!(
+                        before.cumulative_interest_usd,
+                        after.cumulative_interest_usd
+                    );
+
+                    assert_unchanged!(
+                        before.cumulative_interest_snapshot,
+                        after.cumulative_interest_snapshot
+                    );
+
+                    assert_unchanged!(before.collateral_usd, after.collateral_usd);
+                }
+            }
+        }
+    }
+}

--- a/programs/perpetuals/tests/native/utils/fixtures.rs
+++ b/programs/perpetuals/tests/native/utils/fixtures.rs
@@ -77,7 +77,8 @@ pub fn oracle_params_regular(oracle_account: Pubkey) -> OracleParams {
         oracle_type: OracleType::Custom,
         oracle_authority: Pubkey::default(),
         max_price_error: 1_000_000,
-        max_price_age_sec: 30,
+        // Price never go stale in tests
+        max_price_age_sec: u32::MAX,
     }
 }
 

--- a/programs/perpetuals/tests/native/utils/utils.rs
+++ b/programs/perpetuals/tests/native/utils/utils.rs
@@ -20,6 +20,17 @@ use {
 
 pub const ANCHOR_DISCRIMINATOR_SIZE: usize = 8;
 
+#[macro_export]
+macro_rules! assert_unchanged {
+    ($before:expr, $after:expr) => {
+        assert_eq!(
+            $before, $after,
+            "Values are not the same: {:?} != {:?}",
+            $before, $after
+        );
+    };
+}
+
 pub fn create_and_fund_account(address: &Pubkey, program_test: &mut ProgramTest) {
     program_test.add_account(
         *address,


### PR DESCRIPTION
Hello, this PR provide a solution to the following issues:

## Issue 1

The function `add_position` lockup tokens on the `custody`:

```
        stats.locked_amount = math::checked_add(stats.locked_amount, position.locked_amount)?;
```

https://github.com/solana-labs/perpetuals/blob/eb9fe0a6f962665faf736ee068c4d77fd75c825c/programs/perpetuals/src/state/custody.rs#L463C1-L463C95

The problem is that when it's a short position, the `locked_amount` is in collateral unit.

https://github.com/solana-labs/perpetuals/blob/eb9fe0a6f962665faf736ee068c4d77fd75c825c/programs/perpetuals/src/instructions/open_position.rs#L215C2-L215C2

Example: with maxpayoff at 100%, when shorting 1 ETH. Today we're locking up 1500 ETH from the ETH custody (instead of 1 ETH).

--------------

## Issue 2

The checks on `max_position_locked_usd` and `max_total_locked_usd` should be made on the locked token - which is the collateral custody in case of short.


