### PR TITLE
Fix missing default oracleAuthority in CLI

### DIFF
--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -85,6 +85,7 @@ async function addCustody(
     maxPriceAgeSec: 60,
     oracleType: { [oracleType]: {} },
     oracleAccount: tokenOracle,
+    oracleAuthority: PublicKey.default, // By default, permissionless oracle price update is not allowed.
   };
 
   const pricingConfig: PricingParams = {


### PR DESCRIPTION
Tested that `init` CLI command works with this change 

(note:  deploying teams still need to update `OracleParams` config loading to include `oracleAuthority: ...`)

<img width="1764" alt="Screenshot 2023-10-26 at 3 13 58 PM" src="https://github.com/solana-labs/perpetuals/assets/1387955/06da9db5-50c1-4c93-956c-f43e5d7eb8dd">
